### PR TITLE
Error about ScaleFactor uses Int

### DIFF
--- a/display.go
+++ b/display.go
@@ -13,7 +13,7 @@ type DisplayOptions struct {
 	Bounds       *RectangleOptions `json:"bounds,omitempty"`
 	ID           *int              `json:"id,omitempty"`
 	Rotation     *int              `json:"rotation,omitempty"` // 0, 90, 180 or 270
-	ScaleFactor  *int              `json:"scaleFactor,omitempty"`
+	ScaleFactor  *float64          `json:"scaleFactor,omitempty"`
 	Size         *SizeOptions      `json:"size,omitempty"`
 	TouchSupport *string           `json:"touchSupport,omitempty"` // available, unavailable or unknown
 	WorkArea     *RectangleOptions `json:"workArea,omitempty"`
@@ -47,7 +47,7 @@ func (d Display) Rotation() int {
 }
 
 // ScaleFactor returns the display scale factor
-func (d Display) ScaleFactor() int {
+func (d Display) ScaleFactor() float64 {
 	return *d.o.ScaleFactor
 }
 


### PR DESCRIPTION
`ERRO[0000] json: cannot unmarshal number 1.5 into Go struct field DisplayOptions.scaleFactor of type int while unmarshaling {"name":"app.event.ready","targetID":"main","displays":{"all":[{"id":2528732444,"bounds":{"x":0,"y":0,"width":2560,"height":1440},"workArea":{"x":0,"y":0,"width":2560,"height":1400},"size":{"width":2560,"height":1440},"workAreaSize":{"width":2560,"height":1400},"scaleFactor":1.5,"rotation":0,"touchSupport":"unknown"}],"primary":{"id":2528732444,"bounds":{"x":0,"y":0,"width":2560,"height":1440},"workArea":{"x":0,"y":0,"width":2560,"height":1400},"size":{"width":2560,"height":1440},"workAreaSize":{"width":2560,"height":1400},"scaleFactor":1.5,"rotation":0,"touchSupport":"unknown"}}}`