### PR TITLE
fixed some race conditions

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -11,8 +11,14 @@ func TestDispatcher(t *testing.T) {
 	// Init
 	var d = newDispatcher()
 	defer d.close()
-	go d.start()
-	var wg = &sync.WaitGroup{}
+
+	waitChan := make(chan struct{})
+	go func() {
+		d.start()
+		waitChan <- struct{}{}
+	}()
+
+	var wg = sync.WaitGroup{}
 	var dispatched = []int{}
 
 	// Test adding listener
@@ -50,5 +56,6 @@ func TestDispatcher(t *testing.T) {
 
 	// Test close
 	d.close()
-	assert.Nil(t, d.cq)
+	<-waitChan
+	d.close() // this shouldn't try to close the channel again and therefore don't panic
 }

--- a/provisioner.go
+++ b/provisioner.go
@@ -58,7 +58,7 @@ var (
 
 // Provisioner represents an object capable of provisioning Astilectron
 type Provisioner interface {
-	Provision(ctx context.Context, d Dispatcher, appName, os, arch string, p Paths) error
+	Provision(ctx context.Context, d *Dispatcher, appName, os, arch string, p Paths) error
 }
 
 // mover is a function that moves a package
@@ -93,7 +93,7 @@ func provisionStatusElectronKey(os, arch string) string {
 
 // Provision implements the provisioner interface
 // TODO Package app using electron instead of downloading Electron + Astilectron separately
-func (p *defaultProvisioner) Provision(ctx context.Context, d Dispatcher, appName, os, arch string, paths Paths) (err error) {
+func (p *defaultProvisioner) Provision(ctx context.Context, d *Dispatcher, appName, os, arch string, paths Paths) (err error) {
 	// Retrieve provision status
 	var s ProvisionStatus
 	if s, err = p.ProvisionStatus(paths); err != nil {
@@ -177,12 +177,12 @@ func (p *defaultProvisioner) updateProvisionStatus(paths Paths, s *ProvisionStat
 }
 
 // provisionAstilectron provisions astilectron
-func (p *defaultProvisioner) provisionAstilectron(ctx context.Context, d Dispatcher, paths Paths, s ProvisionStatus) error {
+func (p *defaultProvisioner) provisionAstilectron(ctx context.Context, d *Dispatcher, paths Paths, s ProvisionStatus) error {
 	return p.provisionPackage(ctx, d, paths, s.Astilectron, p.moverAstilectron, "Astilectron", VersionAstilectron, paths.AstilectronUnzipSrc(), paths.AstilectronDirectory(), nil)
 }
 
 // provisionElectron provisions electron
-func (p *defaultProvisioner) provisionElectron(ctx context.Context, d Dispatcher, paths Paths, s ProvisionStatus, appName, os, arch string) error {
+func (p *defaultProvisioner) provisionElectron(ctx context.Context, d *Dispatcher, paths Paths, s ProvisionStatus, appName, os, arch string) error {
 	return p.provisionPackage(ctx, d, paths, s.Electron[provisionStatusElectronKey(os, arch)], p.moverElectron, "Electron", VersionElectron, paths.ElectronUnzipSrc(), paths.ElectronDirectory(), func() (err error) {
 		switch os {
 		case "darwin":
@@ -197,7 +197,7 @@ func (p *defaultProvisioner) provisionElectron(ctx context.Context, d Dispatcher
 }
 
 // provisionPackage provisions a package
-func (p *defaultProvisioner) provisionPackage(ctx context.Context, d Dispatcher, paths Paths, s *ProvisionStatusPackage, m mover, name, version, pathUnzipSrc, pathDirectory string, finish func() error) (err error) {
+func (p *defaultProvisioner) provisionPackage(ctx context.Context, d *Dispatcher, paths Paths, s *ProvisionStatusPackage, m mover, name, version, pathUnzipSrc, pathDirectory string, finish func() error) (err error) {
 	// Package has already been provisioned
 	if s != nil && s.Version == version {
 		astilog.Debugf("%s has already been provisioned to version %s, moving on...", name, version)

--- a/provisioner_test.go
+++ b/provisioner_test.go
@@ -37,7 +37,7 @@ func TestDefaultProvisioner(t *testing.T) {
 	p.astilectronUnzipSrc = filepath.Join(p.astilectronDownloadDst, "astilectron")
 	p.astilectronDownloadSrc = s.URL + "/provisioner/astilectron"
 	p.electronDownloadSrc = s.URL + "/provisioner/electron/linux"
-	err = DefaultProvisioner.Provision(context.Background(), *d, "", "linux", "amd64", *p)
+	err = DefaultProvisioner.Provision(context.Background(), d, "", "linux", "amd64", *p)
 	assert.NoError(t, err)
 	testProvisionerSuccessful(t, *p, "linux", "amd64")
 
@@ -45,7 +45,7 @@ func TestDefaultProvisioner(t *testing.T) {
 	mh.e = true
 	os.Remove(p.AstilectronDownloadDst())
 	os.Remove(p.ElectronDownloadDst())
-	err = DefaultProvisioner.Provision(context.Background(), *d, "", "linux", "amd64", *p)
+	err = DefaultProvisioner.Provision(context.Background(), d, "", "linux", "amd64", *p)
 	assert.NoError(t, err)
 	testProvisionerSuccessful(t, *p, "linux", "amd64")
 
@@ -57,7 +57,7 @@ func TestDefaultProvisioner(t *testing.T) {
 	p.astilectronUnzipSrc = filepath.Join(p.astilectronDownloadDst, "astilectron")
 	p.astilectronDownloadSrc = s.URL + "/provisioner/astilectron"
 	p.electronDownloadSrc = s.URL + "/provisioner/electron/windows"
-	err = DefaultProvisioner.Provision(context.Background(), *d, "", "windows", "amd64", *p)
+	err = DefaultProvisioner.Provision(context.Background(), d, "", "windows", "amd64", *p)
 	assert.NoError(t, err)
 	testProvisionerSuccessful(t, *p, "windows", "amd64")
 
@@ -68,7 +68,7 @@ func TestDefaultProvisioner(t *testing.T) {
 	p.astilectronUnzipSrc = filepath.Join(p.astilectronDownloadDst, "astilectron")
 	p.astilectronDownloadSrc = s.URL + "/provisioner/astilectron"
 	p.electronDownloadSrc = s.URL + "/provisioner/electron/darwin"
-	err = DefaultProvisioner.Provision(context.Background(), *d, "", "darwin", "amd64", *p)
+	err = DefaultProvisioner.Provision(context.Background(), d, "", "darwin", "amd64", *p)
 	assert.NoError(t, err)
 	testProvisionerSuccessful(t, *p, "darwin", "amd64")
 
@@ -81,7 +81,7 @@ func TestDefaultProvisioner(t *testing.T) {
 	p.astilectronUnzipSrc = filepath.Join(p.astilectronDownloadDst, "astilectron")
 	p.astilectronDownloadSrc = s.URL + "/provisioner/astilectron"
 	p.electronDownloadSrc = s.URL + "/provisioner/electron/darwin"
-	err = DefaultProvisioner.Provision(context.Background(), *d, o.AppName, "darwin", "amd64", *p)
+	err = DefaultProvisioner.Provision(context.Background(), d, o.AppName, "darwin", "amd64", *p)
 	assert.NoError(t, err)
 	testProvisionerSuccessful(t, *p, "darwin", "amd64")
 	// Rename
@@ -133,7 +133,7 @@ func TestNewDisembedderProvisioner(t *testing.T) {
 	pvb := NewDisembedderProvisioner(mockedDisembedder, "astilectron", "electron/linux")
 
 	// Test provision
-	err = pvb.Provision(context.Background(), *d, "", "linux", "amd64", *p)
+	err = pvb.Provision(context.Background(), d, "", "linux", "amd64", *p)
 	assert.NoError(t, err)
 	testProvisionerSuccessful(t, *p, "linux", "amd64")
 }


### PR DESCRIPTION
I think i've fixed them all

```
==================
WARNING: DATA RACE
Read at 0x00c42007f9c0 by goroutine 17:
  github.com/asticode/go-astilectron.(*reader).read()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/reader.go:65 +0x5cf

Previous write at 0x00c42007f9c0 by main goroutine:
  github.com/asticode/go-astilectron.(*Dispatcher).addListener()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/dispatcher.go:45 +0x212
  github.com/asticode/go-astilectron.(*Astilectron).On()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:130 +0x85
  github.com/asticode/go-astilectron.synchronousFunc()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/helper.go:155 +0x15e
  github.com/asticode/go-astilectron.(*Astilectron).executeCmd()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:258 +0x160
  github.com/asticode/go-astilectron.(*Astilectron).execute()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:250 +0x645
  github.com/asticode/go-astilectron.(*Astilectron).Start()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:153 +0x123
  main.main()
      /home/rkaufmann/go/src/github.com/HeavyHorst/electropdf/main.go:26 +0xc6

Goroutine 17 (running) created at:
  github.com/asticode/go-astilectron.(*Astilectron).acceptTCP()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:232 +0x83
==================
==================
WARNING: DATA RACE
Write at 0x00c4200a62c8 by goroutine 9:
  github.com/asticode/go-astilectron.(*Astilectron).Stop()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:333 +0x128
  github.com/asticode/go-astilectron.New.func1()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:98 +0x5a
  github.com/asticode/go-astilectron.(*Dispatcher).start()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/dispatcher.go:81 +0xea

Previous read at 0x00c4200a62c8 by main goroutine:
  main.main()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:339 +0x3bb

Goroutine 9 (running) created at:
  github.com/asticode/go-astilectron.(*Astilectron).Start()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:139 +0xd3
  main.main()
      /home/rkaufmann/go/src/github.com/HeavyHorst/electropdf/main.go:26 +0xc6
==================

==================
WARNING: DATA RACE
Read at 0x00c42007f9b8 by goroutine 9:
  github.com/asticode/go-astilectron.(*Dispatcher).start()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/dispatcher.go:85 +0x1b3

Previous write at 0x00c42007f9b8 by main goroutine:
  github.com/asticode/go-astilectron.(*Astilectron).Close()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/dispatcher.go:53 +0x2fa
  main.main()
      /home/rkaufmann/go/src/github.com/HeavyHorst/electropdf/main.go:44 +0x3cd

Goroutine 9 (running) created at:
  github.com/asticode/go-astilectron.(*Astilectron).Start()
      /home/rkaufmann/go/src/github.com/asticode/go-astilectron/astilectron.go:139 +0xd3
  main.main()
      /home/rkaufmann/go/src/github.com/HeavyHorst/electropdf/main.go:26 +0xc6
==================

```