### PR TITLE
fix "Can't use synchronousEvent inside a listener"-Issue

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -11,10 +11,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/asticode/go-astilog"
-	"github.com/asticode/go-astitools/context"
-	"github.com/asticode/go-astitools/exec"
 	"github.com/pkg/errors"
+	"github.com/tehsphinx/go-astilog"
+	"github.com/tehsphinx/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/exec"
 )
 
 // Versions

--- a/helper.go
+++ b/helper.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/asticode/go-astilog"
-	"github.com/asticode/go-astitools/context"
-	"github.com/asticode/go-astitools/http"
-	"github.com/asticode/go-astitools/io"
-	"github.com/asticode/go-astitools/zip"
 	"github.com/pkg/errors"
+	"github.com/tehsphinx/go-astilog"
+	"github.com/tehsphinx/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/http"
+	"github.com/tehsphinx/go-astitools/io"
+	"github.com/tehsphinx/go-astitools/zip"
 )
 
 // Download is a cancellable function that downloads a src into a dst using a specific *http.Client and cleans up on

--- a/helper_test.go
+++ b/helper_test.go
@@ -2,20 +2,18 @@ package astilectron
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 
-	"fmt"
-
-	"sync"
-
-	"github.com/asticode/go-astitools/context"
 	"github.com/pkg/errors"
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 // mockedHandler is a mocked handler

--- a/menu.go
+++ b/menu.go
@@ -3,7 +3,7 @@ package astilectron
 import (
 	"context"
 
-	"github.com/asticode/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 // Menu event names

--- a/menu_item.go
+++ b/menu_item.go
@@ -3,7 +3,7 @@ package astilectron
 import (
 	"context"
 
-	"github.com/asticode/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 // Menu item event names

--- a/menu_item_test.go
+++ b/menu_item_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/asticode/go-astitools/context"
 	"github.com/stretchr/testify/assert"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 func TestMenuItem_ToEvent(t *testing.T) {

--- a/menu_test.go
+++ b/menu_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/asticode/go-astitools/context"
 	"github.com/stretchr/testify/assert"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 func TestMenu_ToEvent(t *testing.T) {

--- a/object.go
+++ b/object.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/asticode/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 // Object errors

--- a/object_test.go
+++ b/object_test.go
@@ -3,8 +3,8 @@ package astilectron
 import (
 	"testing"
 
-	"github.com/asticode/go-astitools/context"
 	"github.com/stretchr/testify/assert"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 func TestObject_IsActionable(t *testing.T) {

--- a/provisioner.go
+++ b/provisioner.go
@@ -10,10 +10,10 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/asticode/go-astilog"
-	"github.com/asticode/go-astitools/os"
-	"github.com/asticode/go-astitools/regexp"
 	"github.com/pkg/errors"
+	"github.com/tehsphinx/go-astilog"
+	"github.com/tehsphinx/go-astitools/os"
+	"github.com/tehsphinx/go-astitools/regexp"
 )
 
 // Provision event names

--- a/reader.go
+++ b/reader.go
@@ -3,10 +3,8 @@ package astilectron
 import (
 	"bufio"
 	"bytes"
-	"io"
-
 	"encoding/json"
-
+	"io"
 	"strings"
 
 	"github.com/asticode/go-astilog"
@@ -62,6 +60,7 @@ func (r *reader) read() {
 		}
 
 		// Dispatch
-		r.d.Dispatch(e)
+		// needs goroutine so reader does not wait for dispatching
+		go r.d.Dispatch(e)
 	}
 }

--- a/reader.go
+++ b/reader.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/asticode/go-astilog"
+	"github.com/tehsphinx/go-astilog"
 )
 
 // reader represents an object capable of reading in the TCP server

--- a/reader_test.go
+++ b/reader_test.go
@@ -60,7 +60,8 @@ func TestReader(t *testing.T) {
 	// Test read
 	go r.read()
 	wg.Wait()
-	assert.Equal(t, []int{1, 2}, dispatched)
+	assert.Contains(t, dispatched, 1)
+	assert.Contains(t, dispatched, 2)
 
 	// Test close
 	r.close()

--- a/reader_test.go
+++ b/reader_test.go
@@ -39,13 +39,18 @@ func TestReader(t *testing.T) {
 	go d.start()
 	var wg = &sync.WaitGroup{}
 	var dispatched = []int{}
+	var dispatchedMutex = sync.Mutex{}
 	d.addListener("1", "1", func(e Event) (deleteListener bool) {
+		dispatchedMutex.Lock()
 		dispatched = append(dispatched, 1)
+		dispatchedMutex.Unlock()
 		wg.Done()
 		return
 	})
 	d.addListener("2", "2", func(e Event) (deleteListener bool) {
+		dispatchedMutex.Lock()
 		dispatched = append(dispatched, 2)
+		dispatchedMutex.Unlock()
 		wg.Done()
 		return
 	})

--- a/sub_menu.go
+++ b/sub_menu.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/asticode/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 // Sub menu event names

--- a/sub_menu_test.go
+++ b/sub_menu_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/asticode/go-astitools/context"
 	"github.com/stretchr/testify/assert"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 func TestSubMenu_ToEvent(t *testing.T) {

--- a/tray.go
+++ b/tray.go
@@ -1,6 +1,6 @@
 package astilectron
 
-import "github.com/asticode/go-astitools/context"
+import "github.com/tehsphinx/go-astitools/context"
 
 // Tray event names
 const (

--- a/tray_test.go
+++ b/tray_test.go
@@ -3,8 +3,8 @@ package astilectron
 import (
 	"testing"
 
-	"github.com/asticode/go-astitools/context"
 	"github.com/stretchr/testify/assert"
+	"github.com/tehsphinx/go-astitools/context"
 )
 
 func TestTray_Actions(t *testing.T) {

--- a/window.go
+++ b/window.go
@@ -3,9 +3,9 @@ package astilectron
 import (
 	"net/url"
 
-	"github.com/asticode/go-astitools/context"
-	"github.com/asticode/go-astitools/url"
 	"github.com/pkg/errors"
+	"github.com/tehsphinx/go-astitools/context"
+	"github.com/tehsphinx/go-astitools/url"
 )
 
 // Window event names

--- a/writer.go
+++ b/writer.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/asticode/go-astilog"
 	"github.com/pkg/errors"
+	"github.com/tehsphinx/go-astilog"
 )
 
 // writer represents an object capable of writing in the TCP server


### PR DESCRIPTION
Events are really synchronous now, waiting for the all listeners for finish before moving on.

Just to underline the importance of fixing this issue here a simple example that does not work with the current code:
- Create a application that minimizes to tray on startup
- Add a menu item to the tray that shows the main window

```
[]*astilectron.MenuItemOptions{
		{
			Label:   astilectron.PtrStr("Show"),
			OnClick: func(e astilectron.Event) (deleteListener bool) {
				// this call will make the dispatcher hang and block it from executing any more events
				window.Show()
				return
			},
		},
}
```