### PR TITLE
fix "Can't use synchronousEvent inside a listener"-Issue

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -68,9 +68,7 @@ func (d *Dispatcher) delListener(targetID, eventName string, id int) {
 
 // Dispatch dispatches an event
 func (d *Dispatcher) Dispatch(e Event) {
-	done := make(chan bool)
 	d.c <- e
-	<-done
 }
 
 // start starts the dispatcher and listens to dispatched events

--- a/reader.go
+++ b/reader.go
@@ -60,7 +60,6 @@ func (r *reader) read() {
 		}
 
 		// Dispatch
-		// needs goroutine so reader does not wait for dispatching
-		go r.d.Dispatch(e)
+		r.d.Dispatch(e)
 	}
 }

--- a/reader.go
+++ b/reader.go
@@ -3,10 +3,8 @@ package astilectron
 import (
 	"bufio"
 	"bytes"
-	"io"
-
 	"encoding/json"
-
+	"io"
 	"strings"
 
 	"github.com/asticode/go-astilog"
@@ -62,6 +60,7 @@ func (r *reader) read() {
 		}
 
 		// Dispatch
-		r.d.Dispatch(e)
+		// needs goroutine so reader does not wait for dispatching
+		go r.d.Dispatch(e)
 	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -60,7 +60,8 @@ func TestReader(t *testing.T) {
 	// Test read
 	go r.read()
 	wg.Wait()
-	assert.Equal(t, []int{1, 2}, dispatched)
+	assert.Contains(t, dispatched, 1)
+	assert.Contains(t, dispatched, 2)
 
 	// Test close
 	r.close()

--- a/reader_test.go
+++ b/reader_test.go
@@ -39,13 +39,18 @@ func TestReader(t *testing.T) {
 	go d.start()
 	var wg = &sync.WaitGroup{}
 	var dispatched = []int{}
+	var dispatchedMutex = sync.Mutex{}
 	d.addListener("1", "1", func(e Event) (deleteListener bool) {
+		dispatchedMutex.Lock()
 		dispatched = append(dispatched, 1)
+		dispatchedMutex.Unlock()
 		wg.Done()
 		return
 	})
 	d.addListener("2", "2", func(e Event) (deleteListener bool) {
+		dispatchedMutex.Lock()
 		dispatched = append(dispatched, 2)
+		dispatchedMutex.Unlock()
 		wg.Done()
 		return
 	})


### PR DESCRIPTION
New pull request to get rid of fork commit:

Events are really synchronous now, waiting for the all listeners for finish before moving on.

Just to underline the importance of fixing this issue here a simple example that does not work with the current code:
- Create a application that minimizes to tray on startup
- Add a menu item to the tray that shows the main window

```
[]*astilectron.MenuItemOptions{
		{
			Label:   astilectron.PtrStr("Show"),
			OnClick: func(e astilectron.Event) (deleteListener bool) {
				// this call will make the dispatcher hang and block it from executing any more events
				window.Show()
				return
			},
		},
}
```