### PR TITLE
Add ability to test app using selenium

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -79,6 +79,10 @@ func New(o Options) (a *Astilectron, err error) {
 		err = errors.Wrapf(err, "OS %s is invalid")
 		return
 	}
+	//check AcceptTCPTimeout
+	if o.AcceptTCPTimeout == 0 {
+		o.AcceptTCPTimeout = 30 * time.Second
+	}
 
 	// Init
 	a = &Astilectron{

--- a/astilectron.go
+++ b/astilectron.go
@@ -29,6 +29,7 @@ var (
 		"linux":   true,
 		"windows": true,
 	}
+	defaultAcceptTCPTimeout = 30 * time.Second
 )
 
 // App event names
@@ -81,7 +82,7 @@ func New(o Options) (a *Astilectron, err error) {
 	}
 	//check AcceptTCPTimeout
 	if o.AcceptTCPTimeout == 0 {
-		o.AcceptTCPTimeout = 30 * time.Second
+		o.AcceptTCPTimeout = defaultAcceptTCPTimeout
 	}
 
 	// Init

--- a/executer.go
+++ b/executer.go
@@ -1,0 +1,26 @@
+package astilectron
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/asticode/go-astilog"
+	"github.com/pkg/errors"
+)
+
+// Executer represents an object capable of executing Astilectron run command
+type Executer func(a *Astilectron, cmd *exec.Cmd) (err error)
+
+// DefaultExecuter represents the default executer
+var DefaultExecuter = func(a *Astilectron, cmd *exec.Cmd) (err error) {
+	// Start command
+	astilog.Debugf("Starting cmd %s", strings.Join(cmd.Args, " "))
+	if err = cmd.Start(); err != nil {
+		err = errors.Wrapf(err, "starting cmd %s failed", strings.Join(cmd.Args, " "))
+		return
+	}
+
+	// Watch command
+	go a.watchCmd(cmd)
+	return
+}

--- a/executer.go
+++ b/executer.go
@@ -12,7 +12,7 @@ import (
 type Executer func(a *Astilectron, cmd *exec.Cmd) (err error)
 
 // DefaultExecuter represents the default executer
-var DefaultExecuter = func(a *Astilectron, cmd *exec.Cmd) (err error) {
+func DefaultExecuter(a *Astilectron, cmd *exec.Cmd) (err error) {
 	// Start command
 	astilog.Debugf("Starting cmd %s", strings.Join(cmd.Args, " "))
 	if err = cmd.Start(); err != nil {


### PR DESCRIPTION
PR for this issue https://github.com/asticode/go-astilectron/issues/90
The idea is add some test flag and when it is set the logic will be:
TCP server starts and wait for connections.
We don't start astilectron. Instead of that we create some bash file containing the command that runs astilectron. So.etching like
electron /path/to/astilectron/main.js 127.0.0.1:1111 flags
After that we will have ability to start selenium web driver using this bash file. When the driver starts and bash file executes TCP connection accepts and the app starts in normal way.
Actually in this way we are testing our app which uses astilectron.