### PR TITLE
Expose Window's WindowOptions outside of the astilectron package

### DIFF
--- a/window.go
+++ b/window.go
@@ -67,8 +67,8 @@ var (
 type Window struct {
 	*object
 	callbackIdentifier *identifier
-	o                  *WindowOptions
 	onMessageOnce      sync.Once
+	Options            *WindowOptions
 	Session            *Session
 	url                *url.URL
 }
@@ -160,7 +160,7 @@ func newWindow(o Options, url string, wo *WindowOptions, c *asticontext.Cancelle
 	// Init
 	w = &Window{
 		callbackIdentifier: newIdentifier(),
-		o:                  wo,
+		Options:            wo,
 		object:             newObject(nil, c, d, i, wrt, i.new()),
 	}
 	w.Session = newSession(w.ctx, c, d, i, wrt)
@@ -234,7 +234,7 @@ func (w *Window) Create() (err error) {
 	if err = w.isActionable(); err != nil {
 		return
 	}
-	_, err = synchronousEvent(w.c, w, w.w, Event{Name: EventNameWindowCmdCreate, SessionID: w.Session.id, TargetID: w.id, URL: w.url.String(), WindowOptions: w.o}, EventNameWindowEventDidFinishLoad)
+	_, err = synchronousEvent(w.c, w, w.w, Event{Name: EventNameWindowCmdCreate, SessionID: w.Session.id, TargetID: w.id, URL: w.url.String(), WindowOptions: w.Options}, EventNameWindowEventDidFinishLoad)
 	return
 }
 
@@ -296,9 +296,9 @@ func (w *Window) Move(x, y int) (err error) {
 	if err = w.isActionable(); err != nil {
 		return
 	}
-	w.o.X = PtrInt(x)
-	w.o.Y = PtrInt(y)
-	_, err = synchronousEvent(w.c, w, w.w, Event{Name: EventNameWindowCmdMove, TargetID: w.id, WindowOptions: &WindowOptions{X: w.o.X, Y: w.o.Y}}, EventNameWindowEventMove)
+	w.Options.X = PtrInt(x)
+	w.Options.Y = PtrInt(y)
+	_, err = synchronousEvent(w.c, w, w.w, Event{Name: EventNameWindowCmdMove, TargetID: w.id, WindowOptions: &WindowOptions{X: w.Options.X, Y: w.Options.Y}}, EventNameWindowEventMove)
 	return
 }
 
@@ -366,9 +366,9 @@ func (w *Window) Resize(width, height int) (err error) {
 	if err = w.isActionable(); err != nil {
 		return
 	}
-	w.o.Height = PtrInt(height)
-	w.o.Width = PtrInt(width)
-	_, err = synchronousEvent(w.c, w, w.w, Event{Name: EventNameWindowCmdResize, TargetID: w.id, WindowOptions: &WindowOptions{Height: w.o.Height, Width: w.o.Width}}, EventNameWindowEventResize)
+	w.Options.Height = PtrInt(height)
+	w.Options.Width = PtrInt(width)
+	_, err = synchronousEvent(w.c, w, w.w, Event{Name: EventNameWindowCmdResize, TargetID: w.id, WindowOptions: &WindowOptions{Height: w.Options.Height, Width: w.Options.Width}}, EventNameWindowEventResize)
 	return
 }
 

--- a/window_test.go
+++ b/window_test.go
@@ -15,18 +15,18 @@ func TestNewWindow(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test app name + icon
-	assert.Equal(t, "app name", *w.o.Title)
-	assert.Equal(t, "/path/to/default/icon", *w.o.Icon)
+	assert.Equal(t, "app name", *w.Options.Title)
+	assert.Equal(t, "/path/to/default/icon", *w.Options.Icon)
 
 	// Test in display
 	w, err = a.NewWindowInDisplay(newDisplay(&DisplayOptions{Bounds: &RectangleOptions{PositionOptions: PositionOptions{X: PtrInt(1), Y: PtrInt(2)}, SizeOptions: SizeOptions{Height: PtrInt(5), Width: PtrInt(6)}}}, true), "http://test.com", &WindowOptions{X: PtrInt(3), Y: PtrInt(4)})
 	assert.NoError(t, err)
-	assert.Equal(t, 4, *w.o.X)
-	assert.Equal(t, 6, *w.o.Y)
+	assert.Equal(t, 4, *w.Options.X)
+	assert.Equal(t, 6, *w.Options.Y)
 	w, err = a.NewWindowInDisplay(newDisplay(&DisplayOptions{Bounds: &RectangleOptions{PositionOptions: PositionOptions{X: PtrInt(1), Y: PtrInt(2)}, SizeOptions: SizeOptions{Height: PtrInt(5), Width: PtrInt(6)}}}, true), "http://test.com", &WindowOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, 1, *w.o.X)
-	assert.Equal(t, 2, *w.o.Y)
+	assert.Equal(t, 1, *w.Options.X)
+	assert.Equal(t, 2, *w.Options.Y)
 }
 
 func TestWindow_Actions(t *testing.T) {


### PR DESCRIPTION
I've personally found this to be useful to access the options across my app, rather than storing the state outside of the window separate from the main window object itself. This is great to have to reference over the lifecycle of the app (such as to look up the last resize or positioning values, etc).

Tested with 'go test' and formatted using gofmt