### PR TITLE
Allow go-astilectron to be started from astilectron.

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -188,6 +188,8 @@ func (a *Astilectron) Start() (err error) {
 		if err := a.execute(); err != nil {
 			return errors.Wrap(err, "executing failed")
 		}
+	} else {
+		synchronousFunc(a.canceller, a, func() {}, "app.event.ready")
 	}
 	return nil
 }

--- a/astilectron.go
+++ b/astilectron.go
@@ -125,6 +125,10 @@ func New(o Options) (a *Astilectron, err error) {
 		a.displayPool.update(e.Displays)
 		return
 	})
+	a.On(EventNameAppCmdQuit, func(e Event) (deleteListener bool) {
+		a.Stop()
+		return
+	})
 	return
 }
 

--- a/astilectron.go
+++ b/astilectron.go
@@ -174,6 +174,7 @@ func (a *Astilectron) Start() (err error) {
 	if err = a.listenTCP(); err != nil {
 		return errors.Wrap(err, "listening failed")
 	}
+
 	// Execute
 	if !a.options.SkipAstilectronSetup {
 		if err = a.execute(); err != nil {

--- a/astilectron.go
+++ b/astilectron.go
@@ -200,12 +200,12 @@ func (a *Astilectron) listenTCP() (err error) {
 	// Log
 	astilog.Debug("Listening...")
 
-	port := ""
+	addr := "127.0.0.1:"
 	if a.options.TCPPort != nil {
-		port = fmt.Sprint(*a.options.TCPPort)
+		addr += fmt.Sprint(*a.options.TCPPort)
 	}
 	// Listen
-	if a.listener, err = net.Listen("tcp", "127.0.0.1:"+port); err != nil {
+	if a.listener, err = net.Listen("tcp", addr); err != nil {
 		return errors.Wrap(err, "tcp net.Listen failed")
 	}
 

--- a/astilectron.go
+++ b/astilectron.go
@@ -169,6 +169,8 @@ func (a *Astilectron) Start() (err error) {
 		}
 	}
 
+	// Unfortunately communicating with Electron through stdin/stdout doesn't work on Windows so all communications
+	// will be done through TCP
 	if err := a.listenTCP(); err != nil {
 		return errors.Wrap(err, "listening failed")
 	}

--- a/astilectron.go
+++ b/astilectron.go
@@ -157,17 +157,6 @@ func (a *Astilectron) On(eventName string, l Listener) {
 	a.dispatcher.addListener(targetIDApp, eventName, l)
 }
 
-// WaitOn blocks until the specified event has fired.
-func (a *Astilectron) WaitOn(eventName string) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	a.On(eventName, func(e Event) (deleteListener bool) {
-		defer wg.Done()
-		return true
-	})
-	wg.Wait()
-}
-
 // Start starts Astilectron
 func (a *Astilectron) Start() (err error) {
 	// Log

--- a/astilectron.go
+++ b/astilectron.go
@@ -164,19 +164,19 @@ func (a *Astilectron) Start() (err error) {
 
 	// Provision
 	if !a.options.SkipAstilectronSetup {
-		if err := a.provision(); err != nil {
+		if err = a.provision(); err != nil {
 			return errors.Wrap(err, "provisioning failed")
 		}
 	}
 
 	// Unfortunately communicating with Electron through stdin/stdout doesn't work on Windows so all communications
 	// will be done through TCP
-	if err := a.listenTCP(); err != nil {
+	if err = a.listenTCP(); err != nil {
 		return errors.Wrap(err, "listening failed")
 	}
 	// Execute
 	if !a.options.SkipAstilectronSetup {
-		if err := a.execute(); err != nil {
+		if err = a.execute(); err != nil {
 			return errors.Wrap(err, "executing failed")
 		}
 	} else {

--- a/astilectron.go
+++ b/astilectron.go
@@ -161,7 +161,7 @@ func (a *Astilectron) Start() (err error) {
 		return errors.Wrap(err, "provisioning failed")
 	}
 
-	if err = a.Listen(); err != nil {
+	if _, err = a.Listen(); err != nil {
 		return errors.Wrap(err, "listening failed")
 	}
 	// Execute
@@ -173,10 +173,14 @@ func (a *Astilectron) Start() (err error) {
 }
 
 // Listen creates a TCP server for astilectron to connect to.
-func (a *Astilectron) Listen() error {
+func (a *Astilectron) Listen() (listener net.Listener, err error) {
 	// Unfortunately communicating with Electron through stdin/stdout doesn't work on Windows so all communications
 	// will be done through TCP
-	return a.listenTCP()
+	if err = a.listenTCP(); err != nil {
+		return
+	}
+	listener = a.listener
+	return
 }
 
 // provision provisions Astilectron

--- a/astilectron.go
+++ b/astilectron.go
@@ -182,7 +182,7 @@ func (a *Astilectron) Start() (err error) {
 			return errors.Wrap(err, "executing failed")
 		}
 	} else {
-		synchronousFunc(a.canceller, a, func() {}, "app.event.ready")
+		synchronousFunc(a.canceller, a, nil, "app.event.ready")
 	}
 	return nil
 }

--- a/astilectron.go
+++ b/astilectron.go
@@ -76,7 +76,7 @@ type Options struct {
 	DataDirectoryPath    string
 	ElectronSwitches     []string
 	SingleInstance       bool
-	SkipAstilectronSetup bool // If true, the user must handle provisioning and executing astilectron.
+	SkipSetup bool // If true, the user must handle provisioning and executing astilectron.
 	TCPPort              *int // The port to listen on.
 }
 
@@ -164,7 +164,7 @@ func (a *Astilectron) Start() (err error) {
 	astilog.Debug("Starting...")
 
 	// Provision
-	if !a.options.SkipAstilectronSetup {
+	if !a.options.SkipSetup {
 		if err = a.provision(); err != nil {
 			return errors.Wrap(err, "provisioning failed")
 		}
@@ -177,7 +177,7 @@ func (a *Astilectron) Start() (err error) {
 	}
 
 	// Execute
-	if !a.options.SkipAstilectronSetup {
+	if !a.options.SkipSetup {
 		if err = a.execute(); err != nil {
 			return errors.Wrap(err, "executing failed")
 		}

--- a/astilectron.go
+++ b/astilectron.go
@@ -151,6 +151,17 @@ func (a *Astilectron) On(eventName string, l Listener) {
 	a.dispatcher.addListener(targetIDApp, eventName, l)
 }
 
+// WaitOn blocks until the specified event has fired.
+func (a *Astilectron) WaitOn(eventName string) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	a.On(eventName, func(e Event) (deleteListener bool) {
+		defer wg.Done()
+		return true
+	})
+	wg.Wait()
+}
+
 // Start starts Astilectron
 func (a *Astilectron) Start() (err error) {
 	// Log

--- a/astilectron.go
+++ b/astilectron.go
@@ -1,6 +1,7 @@
 package astilectron
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -75,8 +76,8 @@ type Options struct {
 	DataDirectoryPath    string
 	ElectronSwitches     []string
 	SingleInstance       bool
-	SkipAstilectronSetup bool   // If true, the user must handle provisioning and executing astilectron.
-	TCPPort              string // The port to listen on.
+	SkipAstilectronSetup bool // If true, the user must handle provisioning and executing astilectron.
+	TCPPort              *int // The port to listen on.
 }
 
 // Supported represents Astilectron supported features
@@ -199,8 +200,12 @@ func (a *Astilectron) listenTCP() (err error) {
 	// Log
 	astilog.Debug("Listening...")
 
+	port := ""
+	if a.options.TCPPort != nil {
+		port = fmt.Sprint(*a.options.TCPPort)
+	}
 	// Listen
-	if a.listener, err = net.Listen("tcp", "127.0.0.1:"+a.options.TCPPort); err != nil {
+	if a.listener, err = net.Listen("tcp", "127.0.0.1:"+port); err != nil {
 		return errors.Wrap(err, "tcp net.Listen failed")
 	}
 

--- a/astilectron.go
+++ b/astilectron.go
@@ -161,18 +161,22 @@ func (a *Astilectron) Start() (err error) {
 		return errors.Wrap(err, "provisioning failed")
 	}
 
-	// Unfortunately communicating with Electron through stdin/stdout doesn't work on Windows so all communications
-	// will be done through TCP
-	if err = a.listenTCP(); err != nil {
+	if err = a.Listen(); err != nil {
 		return errors.Wrap(err, "listening failed")
 	}
-
 	// Execute
 	if err = a.execute(); err != nil {
 		err = errors.Wrap(err, "executing failed")
 		return
 	}
 	return
+}
+
+// Listen creates a TCP server for astilectron to connect to.
+func (a *Astilectron) Listen() error {
+	// Unfortunately communicating with Electron through stdin/stdout doesn't work on Windows so all communications
+	// will be done through TCP
+	return a.listenTCP()
 }
 
 // provision provisions Astilectron

--- a/helper.go
+++ b/helper.go
@@ -157,7 +157,9 @@ func synchronousFunc(c *asticontext.Canceller, l listenable, fn func(), eventNam
 		cancel()
 		return true
 	})
-	fn()
+	if fn != nil {
+		fn()
+	}
 	<-ctx.Done()
 	return
 }


### PR DESCRIPTION
This PR implements the changes discussed in issue #193. It is meant to pair with a corresponding update to astilectron (PR asticode/astilectron#22).

# Features

- [Options](https://godoc.org/github.com/asticode/go-astilectron#Options) has new properties:
  - `SkipAstilectronStart`: Skips provisioning and executing astilectron when [Start](https://godoc.org/github.com/asticode/go-astilectron#Astilectron.Start) is called.
  - `TCPPort`: The port to listen on. Defaults to a random available port.
- [New](https://godoc.org/github.com/asticode/go-astilectron#New): Adds a handler for [EventNameAppQuit](https://godoc.org/github.com/asticode/go-astilectron#pkg-constants) that calls [Stop](https://godoc.org/github.com/asticode/go-astilectron#Astilectron.Stop).
- [Start](https://godoc.org/github.com/asticode/go-astilectron#Astilectron.Start): if `options.SkipAstilectronStart` is `true`, Blocks until the `EventNameAppEventReady` event is received.
