### PR TITLE
Log an error if Electron exits non-zero

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -325,10 +325,13 @@ func (a *Astilectron) executeCmd(cmd *exec.Cmd) (err error) {
 // watchCmd watches the cmd execution
 func (a *Astilectron) watchCmd(cmd *exec.Cmd) {
 	// Wait
-	cmd.Wait()
+	err := cmd.Wait()
+	if err != nil {
+		a.l.Errorf("'%v' exited with code: %v", cmd.Path, cmd.ProcessState.ExitCode())
+	}
 
 	// Check the context to determine whether it was a crash
-	if a.worker.Context().Err() != nil {
+	if err != nil || a.worker.Context().Err() != nil {
 		a.l.Debug("App has crashed")
 		a.dispatcher.dispatch(Event{Name: EventNameAppCrash, TargetID: targetIDApp})
 	} else {


### PR DESCRIPTION
This logs an error if the Electron subprocess exits with a non-zero exit code.

I actually started out trying to make this error bubble up and get returned to `go-astilectron-bootstrap`'s `bootstrap.Run` so that our application which uses this receives an error indicating what actually happened instead of `creating tray failed: context canceled` (which isn't very user friendly). While it's true that the context was cancelled, that's not the real error here. 

However, I couldn't really see a great way to do that without wrapping the context that gets passed around, and it turned out to be a larger task than I signed up for. If you have ideas about how to do this in a good way please let me know and I'll consider doing it.