### PR TITLE
Update example HTML filepath

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	// New window
 	var w *astilectron.Window
-	if w, err = a.NewWindow("example/index.html", &astilectron.WindowOptions{
+	if w, err = a.NewWindow("index.html", &astilectron.WindowOptions{
 		Center: astikit.BoolPtr(true),
 		Height: astikit.IntPtr(700),
 		Width:  astikit.IntPtr(700),


### PR DESCRIPTION
The relative HTML filepath was outdated, possibly because main.go used to be in a parent directory. As a result, electron was opening a non-existent HTML file, resulting in a blank window. This change fixes the relative HTML path.