### PR TITLE
Expose a Display's ID

### DIFF
--- a/display.go
+++ b/display.go
@@ -38,6 +38,11 @@ func (d Display) Bounds() Rectangle {
 	}
 }
 
+// ID returns the display's ID
+func (d Display) ID() int64 {
+	return *d.o.ID
+}
+
 // IsPrimary checks whether the display is the primary display
 func (d Display) IsPrimary() bool {
 	return d.primary

--- a/display_test.go
+++ b/display_test.go
@@ -11,6 +11,7 @@ import (
 func TestDisplay(t *testing.T) {
 	var o = &DisplayOptions{
 		Bounds:       &RectangleOptions{PositionOptions: PositionOptions{X: astikit.IntPtr(1), Y: astikit.IntPtr(2)}, SizeOptions: SizeOptions{Height: astikit.IntPtr(3), Width: astikit.IntPtr(4)}},
+		ID:           astikit.Int64Ptr(1234),
 		Rotation:     astikit.IntPtr(5),
 		ScaleFactor:  astikit.Float64Ptr(6),
 		Size:         &SizeOptions{Height: astikit.IntPtr(7), Width: astikit.IntPtr(8)},
@@ -20,6 +21,7 @@ func TestDisplay(t *testing.T) {
 	}
 	var d = newDisplay(o, true)
 	assert.Equal(t, Rectangle{Position: Position{X: 1, Y: 2}, Size: Size{Height: 3, Width: 4}}, d.Bounds())
+	assert.Equal(t, 1234, d.ID())
 	assert.True(t, d.IsPrimary())
 	assert.Equal(t, 5, d.Rotation())
 	assert.Equal(t, float64(6), d.ScaleFactor())


### PR DESCRIPTION
For the project I'm currently working on, I need a (hopefully) reliable way to keep track of displays. I currently use the index of each display from the `Astilectron`'s `Displays()` func, but I'd rather use the underlying ID that's already being stored.