### PR TITLE
window: Add enableRemoteModule flag parameter

### DIFF
--- a/window.go
+++ b/window.go
@@ -174,6 +174,7 @@ type WebPreferences struct {
 	DefaultMonospaceFontSize    *int                   `json:"defaultMonospaceFontSize,omitempty"`
 	DevTools                    *bool                  `json:"devTools,omitempty"`
 	DisableBlinkFeatures        *string                `json:"disableBlinkFeatures,omitempty"`
+	EnableRemoteModule          *bool                  `json:"enableRemoteModule,omitempty"`
 	ExperimentalCanvasFeatures  *bool                  `json:"experimentalCanvasFeatures,omitempty"`
 	ExperimentalFeatures        *bool                  `json:"experimentalFeatures,omitempty"`
 	Images                      *bool                  `json:"images,omitempty"`


### PR DESCRIPTION
As of Electron 10, this field is set to `false` by default, which means the `electron.remote` object is not accessible in the browser window.
By setting this flag to `true`, when using Electron 10, this lets you properly access `electron.remote`, especially for dialogs.