### PR TITLE
Add second instance support 

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -28,14 +28,15 @@ var (
 
 // App event names
 const (
-	EventNameAppClose         = "app.close"
-	EventNameAppCmdQuit       = "app.cmd.quit" // Sends an event to Electron to properly quit the app
-	EventNameAppCmdStop       = "app.cmd.stop" // Cancel the context which results in exiting abruptly Electron's app
-	EventNameAppCrash         = "app.crash"
-	EventNameAppErrorAccept   = "app.error.accept"
-	EventNameAppEventReady    = "app.event.ready"
-	EventNameAppNoAccept      = "app.no.accept"
-	EventNameAppTooManyAccept = "app.too.many.accept"
+	EventNameAppClose               = "app.close"
+	EventNameAppCmdQuit             = "app.cmd.quit" // Sends an event to Electron to properly quit the app
+	EventNameAppCmdStop             = "app.cmd.stop" // Cancel the context which results in exiting abruptly Electron's app
+	EventNameAppCrash               = "app.crash"
+	EventNameAppErrorAccept         = "app.error.accept"
+	EventNameAppEventReady          = "app.event.ready"
+	EventNameAppEventSecondInstance = "app.event.second.instance"
+	EventNameAppNoAccept            = "app.no.accept"
+	EventNameAppTooManyAccept       = "app.too.many.accept"
 )
 
 // Astilectron represents an object capable of interacting with Astilectron

--- a/astilectron.go
+++ b/astilectron.go
@@ -13,7 +13,7 @@ import (
 // Versions
 const (
 	DefaultAcceptTCPTimeout   = 30 * time.Second
-	DefaultVersionAstilectron = "0.41.0"
+	DefaultVersionAstilectron = "0.42.0"
 	DefaultVersionElectron    = "7.1.10"
 )
 

--- a/event.go
+++ b/event.go
@@ -41,6 +41,7 @@ type Event struct {
 	Password            string               `json:"password,omitempty"`
 	Reply               string               `json:"reply,omitempty"`
 	Request             *EventRequest        `json:"request,omitempty"`
+	SecondInstance      *EventSecondInstance `json:"secondInstance,omitempty"`
 	SessionID           string               `json:"sessionId,omitempty"`
 	Supported           *Supported           `json:"supported,omitempty"`
 	TrayOptions         *TrayOptions         `json:"trayOptions,omitempty"`
@@ -114,6 +115,12 @@ type EventRequest struct {
 	Method   string `json:"method,omitempty"`
 	Referrer string `json:"referrer,omitempty"`
 	URL      string `json:"url,omitempty"`
+}
+
+// EventSecondInstance represents data related to a second instance of the app being started
+type EventSecondInstance struct {
+	CommandLine      []string `json:"commandLine,omitempty"`
+	WorkingDirectory string   `json:"workingDirectory,omitempty"`
 }
 
 // EventSubMenu represents a sub menu event


### PR DESCRIPTION
Solves the Go-side of https://github.com/asticode/go-astilectron/issues/284#issue-714926211


This is a follow up to #287, which had an almost working version of second instance support (it just had a slight mismatch of types between JS and Go). 

I tested by modifying the demo to listen to this event and log when it happened. 
Demo changes are available here, I can PR them if you would like:
https://github.com/Joe-Improbable/go-astilectron-demo

Let me know what you think
