### PR TITLE
Allow custom electron path

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -65,6 +65,7 @@ type Options struct {
 	AppName            string
 	AppIconDarwinPath  string // Darwin systems requires a specific .icns file
 	AppIconDefaultPath string
+	CustomElectronPath string
 	BaseDirectoryPath  string
 	DataDirectoryPath  string
 	ElectronSwitches   []string

--- a/paths.go
+++ b/paths.go
@@ -60,11 +60,15 @@ func newPaths(os, arch string, o Options) (p *Paths, err error) {
 	p.astilectronDownloadSrc = AstilectronDownloadSrc(o.VersionAstilectron)
 	p.astilectronDownloadDst = filepath.Join(p.vendorDirectory, fmt.Sprintf("astilectron-v%s.zip", o.VersionAstilectron))
 	p.astilectronUnzipSrc = filepath.Join(p.astilectronDownloadDst, fmt.Sprintf("astilectron-%s", o.VersionAstilectron))
-	p.electronDirectory = filepath.Join(p.vendorDirectory, fmt.Sprintf("electron-%s-%s", os, arch))
-	p.electronDownloadSrc = ElectronDownloadSrc(os, arch, o.VersionElectron)
-	p.electronDownloadDst = filepath.Join(p.vendorDirectory, fmt.Sprintf("electron-%s-%s-v%s.zip", os, arch, o.VersionElectron))
-	p.electronUnzipSrc = p.electronDownloadDst
-	p.initAppExecutable(os, o.AppName)
+	if o.CustomElectronPath == "" {
+		p.electronDirectory = filepath.Join(p.vendorDirectory, fmt.Sprintf("electron-%s-%s", os, arch))
+		p.electronDownloadSrc = ElectronDownloadSrc(os, arch, o.VersionElectron)
+		p.electronDownloadDst = filepath.Join(p.vendorDirectory, fmt.Sprintf("electron-%s-%s-v%s.zip", os, arch, o.VersionElectron))
+		p.electronUnzipSrc = p.electronDownloadDst
+		p.initAppExecutable(os, o.AppName)
+	} else {
+		p.appExecutable = o.CustomElectronPath
+	}
 	return
 }
 

--- a/provisioner.go
+++ b/provisioner.go
@@ -151,6 +151,9 @@ func (p *defaultProvisioner) provisionAstilectron(ctx context.Context, paths Pat
 
 // provisionElectron provisions electron
 func (p *defaultProvisioner) provisionElectron(ctx context.Context, paths Paths, s ProvisionStatus, appName, os, arch, versionElectron string) error {
+	if paths.ElectronUnzipSrc() == "" {
+		return nil
+	}
 	return p.provisionPackage(ctx, paths, s.Electron[provisionStatusElectronKey(os, arch)], p.moverElectron, "Electron", versionElectron, paths.ElectronUnzipSrc(), paths.ElectronDirectory(), func() (err error) {
 		switch os {
 		case "darwin":


### PR DESCRIPTION
This is useful on systems (like NixOS) where the Electron downloaded
by go-astilectron does not work out of the box, but it is possible to
install a working Electron separately.

Refs #309