### PR TITLE
Bump Electron to v11.4.3

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -14,7 +14,7 @@ import (
 const (
 	DefaultAcceptTCPTimeout   = 30 * time.Second
 	DefaultVersionAstilectron = "0.46.0"
-	DefaultVersionElectron    = "11.1.0"
+	DefaultVersionElectron    = "11.4.3"
 )
 
 // Misc vars


### PR DESCRIPTION
Latest patch of major version 11, released 2021-04-14 ([version history](https://www.electronjs.org/docs/tutorial/electron-versioning/history)).

Tested with my (simple) application.