### PR TITLE
Remove option for context isolation

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -13,7 +13,7 @@ import (
 // Versions
 const (
 	DefaultAcceptTCPTimeout   = 30 * time.Second
-	DefaultVersionAstilectron = "0.47.0"
+	DefaultVersionAstilectron = "0.48.0"
 	DefaultVersionElectron    = "11.4.3"
 )
 

--- a/window.go
+++ b/window.go
@@ -166,22 +166,23 @@ type WindowProxyOptions struct {
 // We must use pointers since GO doesn't handle optional fields whereas NodeJS does.
 // Use astikit.BoolPtr, astikit.IntPtr or astikit.StrPtr to fill the struct
 type WebPreferences struct {
-	AllowRunningInsecureContent *bool                  `json:"allowRunningInsecureContent,omitempty"`
-	BackgroundThrottling        *bool                  `json:"backgroundThrottling,omitempty"`
-	BlinkFeatures               *string                `json:"blinkFeatures,omitempty"`
-	ContextIsolation            *bool                  `json:"contextIsolation,omitempty"`
-	DefaultEncoding             *string                `json:"defaultEncoding,omitempty"`
-	DefaultFontFamily           map[string]interface{} `json:"defaultFontFamily,omitempty"`
-	DefaultFontSize             *int                   `json:"defaultFontSize,omitempty"`
-	DefaultMonospaceFontSize    *int                   `json:"defaultMonospaceFontSize,omitempty"`
-	DevTools                    *bool                  `json:"devTools,omitempty"`
-	DisableBlinkFeatures        *string                `json:"disableBlinkFeatures,omitempty"`
-	EnableRemoteModule          *bool                  `json:"enableRemoteModule,omitempty"`
-	ExperimentalCanvasFeatures  *bool                  `json:"experimentalCanvasFeatures,omitempty"`
-	ExperimentalFeatures        *bool                  `json:"experimentalFeatures,omitempty"`
-	Images                      *bool                  `json:"images,omitempty"`
-	Javascript                  *bool                  `json:"javascript,omitempty"`
-	MinimumFontSize             *int                   `json:"minimumFontSize,omitempty"`
+	AllowRunningInsecureContent *bool   `json:"allowRunningInsecureContent,omitempty"`
+	BackgroundThrottling        *bool   `json:"backgroundThrottling,omitempty"`
+	BlinkFeatures               *string `json:"blinkFeatures,omitempty"`
+	// This attribute needs to be false at all time
+	// ContextIsolation            *bool                  `json:"contextIsolation,omitempty"`
+	DefaultEncoding            *string                `json:"defaultEncoding,omitempty"`
+	DefaultFontFamily          map[string]interface{} `json:"defaultFontFamily,omitempty"`
+	DefaultFontSize            *int                   `json:"defaultFontSize,omitempty"`
+	DefaultMonospaceFontSize   *int                   `json:"defaultMonospaceFontSize,omitempty"`
+	DevTools                   *bool                  `json:"devTools,omitempty"`
+	DisableBlinkFeatures       *string                `json:"disableBlinkFeatures,omitempty"`
+	EnableRemoteModule         *bool                  `json:"enableRemoteModule,omitempty"`
+	ExperimentalCanvasFeatures *bool                  `json:"experimentalCanvasFeatures,omitempty"`
+	ExperimentalFeatures       *bool                  `json:"experimentalFeatures,omitempty"`
+	Images                     *bool                  `json:"images,omitempty"`
+	Javascript                 *bool                  `json:"javascript,omitempty"`
+	MinimumFontSize            *int                   `json:"minimumFontSize,omitempty"`
 	// This attribute needs to be true at all time
 	// NodeIntegration             *bool                  `json:"nodeIntegration,omitempty"`
 	NodeIntegrationInWorker *bool                  `json:"nodeIntegrationInWorker,omitempty"`


### PR DESCRIPTION
Removes the option to set `ContextIsolation` from `WindowOptions.WebPreferences`. The property is now hardcoded to false in astilectron (see https://github.com/asticode/astilectron/pull/45).

[Context isolation](https://www.electronjs.org/docs/tutorial/context-isolation) appears to be incompatible with astilectron, but it's enabled by default by Electron starting with major version 12.
Issue: https://github.com/asticode/go-astilectron/issues/318