### PR TITLE
Added SetContentProtection feature to Window

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -13,7 +13,7 @@ import (
 // Versions
 const (
 	DefaultAcceptTCPTimeout   = 30 * time.Second
-	DefaultVersionAstilectron = "0.48.0"
+	DefaultVersionAstilectron = "0.49.0"
 	DefaultVersionElectron    = "11.4.3"
 )
 

--- a/event.go
+++ b/event.go
@@ -27,6 +27,7 @@ type Event struct {
 	CallbackID          string               `json:"callbackId,omitempty"`
 	Code                string               `json:"code,omitempty"`
 	Displays            *EventDisplays       `json:"displays,omitempty"`
+	Enable              *bool                `json:"enable,omitempty"`
 	FilePath            string               `json:"filePath,omitempty"`
 	ID                  *int                 `json:"id,omitempty"`
 	Image               string               `json:"image,omitempty"`

--- a/window.go
+++ b/window.go
@@ -30,6 +30,7 @@ const (
 	EventNameWindowCmdResize                          = "window.cmd.resize"
 	EventNameWindowCmdSetBounds                       = "window.cmd.set.bounds"
 	EventNameWindowCmdRestore                         = "window.cmd.restore"
+	EventNameWindowCmdSetContentProtection            = "window.cmd.set.content.protection"
 	EventNameWindowCmdShow                            = "window.cmd.show"
 	EventNameWindowCmdUnmaximize                      = "window.cmd.unmaximize"
 	EventNameWindowCmdUpdateCustomOptions             = "window.cmd.update.custom.options"
@@ -38,6 +39,7 @@ const (
 	EventNameWindowCmdWebContentsExecuteJavaScript    = "window.cmd.web.contents.execute.javascript"
 	EventNameWindowEventBlur                          = "window.event.blur"
 	EventNameWindowEventClosed                        = "window.event.closed"
+	EventNameWindowEventContentProtectionSet          = "window.event.content.protection.set"
 	EventNameWindowEventDidFinishLoad                 = "window.event.did.finish.load"
 	EventNameWindowEventFocus                         = "window.event.focus"
 	EventNameWindowEventHide                          = "window.event.hide"
@@ -480,6 +482,15 @@ func (w *Window) SetBounds(r RectangleOptions) (err error) {
 	w.o.Y = r.Y
 	w.m.Unlock()
 	_, err = synchronousEvent(w.ctx, w, w.w, Event{Name: EventNameWindowCmdSetBounds, TargetID: w.id, Bounds: &r}, EventNameWindowEventResize)
+	return
+}
+
+// Enable content protection on the window
+func (w *Window) SetContentProtection(enable bool) (err error) {
+	if err = w.ctx.Err(); err != nil {
+		return
+	}
+	_, err = synchronousEvent(w.ctx, w, w.w, Event{Name: EventNameWindowCmdSetContentProtection, TargetID: w.id, Enable: astikit.BoolPtr(enable)}, EventNameWindowEventContentProtectionSet)
 	return
 }
 


### PR DESCRIPTION
This PR implements content protection feature of Electron. Prevents the window contents from being captured by other apps.

More on feature : https://www.electronjs.org/docs/api/browser-window#winsetcontentprotectionenable-macos-windows

Closes #334 