### PR TITLE
Add powerMonitor events

### DIFF
--- a/astilectron.go
+++ b/astilectron.go
@@ -13,7 +13,7 @@ import (
 // Versions
 const (
 	DefaultAcceptTCPTimeout   = 30 * time.Second
-	DefaultVersionAstilectron = "0.53.0"
+	DefaultVersionAstilectron = "0.54.0"
 	DefaultVersionElectron    = "11.4.3"
 )
 

--- a/astilectron.go
+++ b/astilectron.go
@@ -161,6 +161,11 @@ func (a *Astilectron) On(eventName string, l Listener) {
 	a.dispatcher.addListener(targetIDApp, eventName, l)
 }
 
+// OnPowerEvent implements the Listenable interface for power related events
+func (a *Astilectron) OnPowerEvent(eventName string, l Listener) {
+	a.dispatcher.addListener(targetIDPower, eventName, l)
+}
+
 // Start starts Astilectron
 func (a *Astilectron) Start() (err error) {
 	// Log

--- a/astilectron.go
+++ b/astilectron.go
@@ -161,11 +161,6 @@ func (a *Astilectron) On(eventName string, l Listener) {
 	a.dispatcher.addListener(targetIDApp, eventName, l)
 }
 
-// OnPowerEvent implements the Listenable interface for power related events
-func (a *Astilectron) OnPowerEvent(eventName string, l Listener) {
-	a.dispatcher.addListener(targetIDPower, eventName, l)
-}
-
 // Start starts Astilectron
 func (a *Astilectron) Start() (err error) {
 	// Log

--- a/event.go
+++ b/event.go
@@ -7,9 +7,8 @@ import (
 
 // Target IDs
 const (
-	targetIDApp   = "app"
-	targetIDDock  = "dock"
-	targetIDPower = "power"
+	targetIDApp  = "app"
+	targetIDDock = "dock"
 )
 
 // Event represents an event

--- a/event.go
+++ b/event.go
@@ -7,8 +7,9 @@ import (
 
 // Target IDs
 const (
-	targetIDApp  = "app"
-	targetIDDock = "dock"
+	targetIDApp   = "app"
+	targetIDDock  = "dock"
+	targetIDPower = "power"
 )
 
 // Event represents an event

--- a/power.go
+++ b/power.go
@@ -1,0 +1,14 @@
+package astilectron
+
+// Power event names
+const (
+	PowerEventSuspend             = "power.event.suspend"
+	PowerEventResume              = "power.event.resume"
+	PowerEventOnAC                = "power.event.on.ac"
+	PowerEventOnBattery           = "power.event.on.battery"
+	PowerEventShutdown            = "power.event.shutdown"
+	PowerEventLockScreen          = "power.event.lock.screen"
+	PowerEventUnlockScreen        = "power.event.unlock.screen"
+	PowerEventUserDidBecomeActive = "power.event.user.did.become.active"
+	PowerEventUserDidResignActive = "power.event.user.did.resign.active"
+)

--- a/power.go
+++ b/power.go
@@ -2,13 +2,13 @@ package astilectron
 
 // Power event names
 const (
-	PowerEventSuspend             = "power.event.suspend"
-	PowerEventResume              = "power.event.resume"
-	PowerEventOnAC                = "power.event.on.ac"
-	PowerEventOnBattery           = "power.event.on.battery"
-	PowerEventShutdown            = "power.event.shutdown"
-	PowerEventLockScreen          = "power.event.lock.screen"
-	PowerEventUnlockScreen        = "power.event.unlock.screen"
-	PowerEventUserDidBecomeActive = "power.event.user.did.become.active"
-	PowerEventUserDidResignActive = "power.event.user.did.resign.active"
+	EventNamePowerSuspend             = "power.event.suspend"
+	EventNamePowerResume              = "power.event.resume"
+	EventNamePowerOnAC                = "power.event.on.ac"
+	EventNamePowerOnBattery           = "power.event.on.battery"
+	EventNamePowerShutdown            = "power.event.shutdown"
+	EventNamePowerLockScreen          = "power.event.lock.screen"
+	EventNamePowerUnlockScreen        = "power.event.unlock.screen"
+	EventNamePowerUserDidBecomeActive = "power.event.user.did.become.active"
+	EventNamePowerUserDidResignActive = "power.event.user.did.resign.active"
 )


### PR DESCRIPTION
The `powerMonitor` events are attached to the `*astilectron.Astilectron` instance (added a receiver function `OnPowerEvent`).

Fixes #359