### PR TITLE
Fix the error in the event Badge

### DIFF
--- a/dock.go
+++ b/dock.go
@@ -92,7 +92,7 @@ func (d *Dock) SetBadge(badge string) (err error) {
 	if err = d.ctx.Err(); err != nil {
 		return
 	}
-	_, err = synchronousEvent(d.ctx, d, d.w, Event{Name: eventNameDockCmdSetBadge, TargetID: d.id, Badge: badge}, eventNameDockEventBadgeSet)
+	_, err = synchronousEvent(d.ctx, d, d.w, Event{Name: eventNameDockCmdSetBadge, TargetID: d.id, Badge: &badge}, eventNameDockEventBadgeSet)
 	return
 }
 

--- a/event.go
+++ b/event.go
@@ -21,7 +21,7 @@ type Event struct {
 	// A choice was made not to use interfaces since it's a pain in the ass asserting each an every payload afterwards
 	// We use pointers so that omitempty works
 	AuthInfo            *EventAuthInfo       `json:"authInfo,omitempty"`
-	Badge               string               `json:"badge,omitempty"`
+	Badge               *string              `json:"badge,omitempty"`
 	BounceType          string               `json:"bounceType,omitempty"`
 	Bounds              *RectangleOptions    `json:"bounds,omitempty"`
 	CallbackID          string               `json:"callbackId,omitempty"`


### PR DESCRIPTION
which currently does not allow empty strings. Change it to use a String pointer.